### PR TITLE
DockerのMysqlを使って、golangでアクセスする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  mysql:
+    image: mysql:5.6
+    ports:
+      - 3306:3306
+    environment:
+      - MYSQL_ROOT_PASSWORD=
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module tinktur
 
 go 1.18
 
-require github.com/labstack/echo v3.3.10+incompatible
+require (
+	github.com/go-sql-driver/mysql v1.6.0
+	github.com/labstack/echo v3.3.10+incompatible
+)
 
 require (
 	github.com/labstack/gommon v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/gommon v0.3.1 h1:OomWaJXm7xR6L1HmEtGyQf26TEn7V6X88mktX9kee9o=

--- a/main.go
+++ b/main.go
@@ -1,15 +1,31 @@
 package main
 
 import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/labstack/echo"
 
 	"tinktur/interfaces/api/httphandler"
 )
 
+type User struct {
+	ID int
+}
+
 func main() {
+	db, err := sql.Open("mysql", "root@tcp(127.0.0.1:3306)/tinktur")
+	var user User
+
 	e := echo.New()
 
 	_ = e.GET("/ping", httphandler.Ping)
+
+	err = db.QueryRow("SELECT * FROM users WHERE id = ?", 1).Scan(&user.ID)
+	if err == nil {
+		fmt.Println(user.ID)
+	}
 
 	e.Logger.Fatal(e.Start(":1323"))
 }


### PR DESCRIPTION
# 目的
golang から Mysql のサーバーにアクセスをして、結果をとってこれることを確認

# 内容
docker-compose で Mysql サーバーを追加し、golang の database/sql を使ってMysql サーバーにアクセスする
取得した結果を とりあえず fmt.Print で表示して取れていることを確認する
ドメイン分割などはとりあえず考えてはいないので、この後やっていく

# 確認方法
```
## Mysql サーバーを起動して、データを投入しておく
% docker-compose up -d
% mysql -u root -h 127.0.0.1
mysql> CREATE DATABASE tinktur;
mysql> use tinktur;
mysql> insert users(id) values (1);
SELECT * FROM users\G
*************************** 1. row ***************************
id: 1
```
あとはサーバーを起動すればデータが入っているので確認できる